### PR TITLE
Update Fluid Mixins

### DIFF
--- a/src/library/mixin.lua
+++ b/src/library/mixin.lua
@@ -1,7 +1,57 @@
 --[[
 $module Fluid Mixins
 ]]
-local mixin, default_mixins, named_mixins = {}, {}, {}
+
+-- For compatibility with Lua <= 5.1
+local unpack = unpack or table.unpack
+
+local mixin, global_mixins, named_mixins = {}, {}, {}
+
+local base_mixins = {
+    is_mixin = true,
+
+--[[
+% has_mixin(name)
+
+Object Method: Checks if the object it is called on has a mixin applied.
+
+@ name (string) Mixin name.
+: (boolean)
+]]
+    has_mixin = function(t, mixin_list, _, name)
+        if name == 'global' then
+            return global_mixins[mixin.get_class_name(t)] and true or false
+        end
+
+        return mixin_list[name] and true or false
+    end,
+
+--[[
+% has_mixin(name)
+
+Object Method: Applies a mixin to the object it is called on.
+
+@ name (string) Mixin name.
+]]
+    apply_mixin = function(t, mixin_list, mixin_props, name)
+        if mixin_list[name] then
+            error('Mixin \'' .. name .. '\' has already been applied to this object.');
+        end
+
+        local m = mixin.get_mixin(mixin.get_class_name(t), name)
+        for p, v in pairs(m) do
+            -- Take advantage of error checking
+            t[p] = v
+        end
+
+        if m.init then
+            t:init()
+            mixin_props.init = nil
+        end
+
+        mixin_list[name] = true
+    end,
+}
 
 -- Recursively copies a table, or just returns the value if not a table
 local function copy_table(t)
@@ -17,9 +67,28 @@ local function copy_table(t)
     end
 end
 
+-- Catches an error and rethrows it at the specified level
+local function catch_and_rethrow(func, func_name, levels, ...)
+    local success, result = pcall(function(...) return {func(...)} end, ...)
+
+    if not success then
+        -- Strip the original line number
+        _, _, result = result:match('([^:]+):([^:]+): (.+)')
+
+        -- Replace the method name with the correct one
+        if func_name then
+            result = result:gsub('\'func\'', '\'' .. func_name .. '\'')
+        end
+
+        error(result, levels + 1)
+    end
+
+    return unpack(result)
+end
+
 -- Gets the real class name of a Finale object
 -- Some classes have incorrect class names, so this function attempts to resolve them with ducktyping
-local function get_class_name(object)
+function mixin.get_class_name(object)
     if not object or not object.ClassName then return end
     if object:ClassName() == '__FCCollection' and object.ExecuteModal then
         return object.RegisterHandleCommand and 'FCCustomLuaWindow' or 'FCCustomWindow'
@@ -35,7 +104,7 @@ local function is_finale_object(object)
 end
 
 -- Returns a function that handles the fluid interface
-function mixin.create_fluid_proxy(t, func)
+function mixin.create_fluid_proxy(t, func, func_name)
     local function proxy(...)
         local n = select('#', ...)
         -- If no return values, then apply the fluid interface
@@ -51,15 +120,15 @@ function mixin.create_fluid_proxy(t, func)
     end
 
     return function(...)
-        return proxy(func(...))
+        return proxy(catch_and_rethrow(func, func_name, 2, ...))
     end
 end
 
 -- Modifies an existing instance of an FC* object to allow adding mixins and adds primary mixins.
 function mixin.apply_mixin_foundation(object)
     if not object or not is_finale_object(object) or object.is_mixin then return end
-    local class_name = get_class_name(object)
-    local mixin_store = {}
+    local class_name = mixin.get_class_name(object)
+    local mixin_props, mixin_list = {}, {}
     local meta = getmetatable(object)
 
     -- We need to retain a reference to the originals for later
@@ -68,21 +137,34 @@ function mixin.apply_mixin_foundation(object)
 
     meta.__index = function(t, k)
         local prop
+        local real_k = k
 
-        if k == 'is_mixin' then
-            return true
-        elseif mixin_store[k] then
-            prop = mixin_store[k]
-        elseif default_mixins[class_name] and default_mixins[class_name][k] then
-        	prop = default_mixins[class_name][k]
+        if base_mixins[k] then
+            if type(base_mixins[k]) == 'function' then
+                -- This will couple the method to the current instance but this shouldn't be an issue
+                -- because calls to foo.has_mixin(bar, 'baz_mix') instead of bar:has_mixin('baz_mix') shouldn't be happening...
+                prop = function(_, ...) return base_mixins[k](t, mixin_list, mixin_props, ...) end
+            else
+                prop = copy_table(base_mixins[k])
+            end
+        elseif mixin_props[k] then
+            prop = mixin_props[k]
+        elseif global_mixins[class_name] and global_mixins[class_name][k] then
+            -- Only copy over properties, not methods.
+            if type(global_mixins[k]) == 'function' then
+                prop = global_mixins[class_name][k]
+            else
+                mixin_props[k] = copy_table(global_mixins[class_name][k])
+                prop = mixin_props[k]
+            end
         else
             -- Strip trailing underscore if there is one
-            if type(k) == 'string' and k:sub(-1) == '_' then k = k:sub(1, -2) end
-            prop = original_index(t, k)
+            if type(k) == 'string' and k:sub(-1) == '_' then real_k = k:sub(1, -2) end
+            prop = original_index(t, real_k)
         end
 
        if type(prop) == 'function' then
-            return mixin.create_fluid_proxy(t, prop)
+            return mixin.create_fluid_proxy(t, prop, real_k)
         else
             return prop
         end
@@ -96,23 +178,36 @@ function mixin.apply_mixin_foundation(object)
             error('Mixin methods and properties cannot end in an underscore.', 2)
         end
 
-        local v_type = type(original_index(t, k))
+        local type_v_original = type(original_index(t, k))
 
         -- If it's a method, or a property that doesn't exist on the original object, store it
-        if (v_type == 'nil' or v_type == 'function') then
-            mixin_store[k] = v
-        -- Otherwise, try and store it on the original property. If it's read-only, it will fail show the error
-        elseif not pcall(function() original_newindex(t, k, v) end) then
-            -- In the absence of the ability to throw exceptions, replicate the original error
-            error('no member named \'' .. k .. '\'', 2)
-        end
-    end
+        if type_v_original == 'nil' then
+            local type_v_mixin = type(mixin_props[k])
+            local type_v = type(v)
 
-    -- Add default mixin properties
-    for k, v in pairs(default_mixins[class_name] or {}) do
-        if type(v) ~= 'function' then
-            -- Applying to object instead of mixin allows us to utilise the existing error handling 
-            object[k] = copy_table(v)
+            -- Technically, a property could still be erased by setting it to nil and then replacing it with a method afterwards
+            -- But handling that case would mean either storing a list of all properties ever created, or preventing properties from being set to nil.
+            if type_v_mixin ~= 'nil' then
+                if type_v == 'function' and type_v_mixin ~= 'function' then
+                    error('A mixin method cannot be overridden with a property.', 2)
+                elseif type_v_mixin == 'function' and type_v ~= 'function' then
+                    error('A mixin property cannot be overridden with a method.', 2)
+                end
+            end
+
+            mixin_props[k] = v
+
+        -- If it's a method, we can override it but only with another method
+        elseif type_v_original == 'function' then
+            if type(v) ~= 'function' then
+                error('A mixin method cannot be overridden with a property.', 2)
+            end
+
+            mixin_props[k] = v
+
+        -- Otherwise, try and store it on the original property. If it's read-only, it will fail and we show the error
+        else
+            catch_and_rethrow(original_newindex, nil, 2, t, k, v)
         end
     end
 
@@ -120,117 +215,87 @@ function mixin.apply_mixin_foundation(object)
 end
 
 --[[
-% register_default(class, prop[, value])
+% register_global_mixin(class, prop[, value])
 
-Register a mixin for a Finale class that will be applied globally. Note that methods are applied retroactively but properties will only be applied to new instances.
+Library Method: Register a mixin for a finale class that will be applied globally (ie to all instances of the specified classes, including existing instances). Properties and methods cannot end in an underscore.
 
-@ class (string|array) The class (or an array of classes) to apply the mixin to.
+@ class (string|array) The target class (or an array of classes).
 @ prop (string|table) Either the property name, or a table with pairs of (string) = (mixed)
 @ value [mixed] OPTIONAL: Method or property value. Will be ignored if prop is a table.
 ]]
-function mixin.register_default(class, prop, value)
-    class = type(class) ~= 'table' and {class} or class
-    prop = type(prop) ~= 'table' and {[prop] = value} or prop
+function mixin.register_global_mixin(class, prop, value)
+    class = type(class) == 'table' and class or {class}
+    prop = type(prop) == 'table' and prop or {[prop] = value}
 
     for _, c in ipairs(class) do
         for p, v in pairs(prop) do
             if type(p) == 'string' and p:sub(-1) ~= '_' then
-                default_mixins[c] = default_mixins[c] or {}
-                default_mixins[c][p] = copy_table(v)
+                global_mixins[c] = global_mixins[c] or {}
+                global_mixins[c][p] = copy_table(v)
             end
         end
     end
 end
 
 --[[
-% register_named(class, mixin_name, prop[, value])
+% register_mixin(class, mixin_name, prop[, value])
 
-Register a named mixin which can then be applied by calling apply_named. If a named mixin requires setup, include a method called `init` that accepts zero arguments. It will be called when the mixin is applied.
+Library Method: Register a named mixin which can then be applied by calling the target object's apply_mixin method. If a named mixin requires a 'constructor', include a method called 'init' that accepts zero arguments. It will be called when the mixin is applied. Properties and methods cannot end in an underscore.
 
 @ class (string|array) The class (or an array of classes) to apply the mixin to.
 @ mixin_name (string|array) Mixin name, or an array of names.
 @ prop (string|table) Either the property name, or a table with pairs of (string) = (mixed)
 @ value [mixed] OPTIONAL: Method or property value. Will be ignored if prop is a table.
 ]]
-function mixin.register_named(class, mixin_name, method, func)
-    mixin_name = type(mixin_name) ~= 'table' and {mixin_name} or mixin_name
-    class = type(class) ~= 'table' and {class} or class
-    prop = type(prop) ~= 'table' and {[prop] = value} or prop
+function mixin.register_mixin(class, mixin_name, prop, value)
+    mixin_name = type(mixin_name) == 'table' and mixin_name or {mixin_name}
+    class = type(class) == 'table' and class or {class}
+    prop = type(prop) == 'table' and prop or {[prop] = value}
 
     for _, n in ipairs(mixin_name) do
+        if n == 'global' then
+            error('A mixin cannot be named \'global\'.',  2)
+        end
+
         for _, c in ipairs(class) do
             named_mixins[c] = named_mixins[c] or {}
-            named_mixins[c][n] = named_mixins[c][n] or {}
+
+            if named_mixins[c][n] then
+                error('Named mixins can only be registered once per class.', 2)
+            else
+                named_mixins[c][n] = {}
+            end
+
             for p, v in pairs(prop) do
-                if type(p) == 'string' and m:sub(-1) ~= '_' then named_mixins[c][n][p] = copy_table(v) end
+                if type(p) == 'string' and p:sub(-1) ~= '_' then named_mixins[c][n][p] = copy_table(v) end
             end
         end
     end
 end
 
 --[[
-% get_default(class, prop)
+% get_global_mixin(class, prop)
 
-Retrieves the value of a default mixin.
+Library Method: Returns a copy of all methods and properties of a global mixin.
 
-@ class (string) The Finale class name.
-@ prop (string) The name of the property or method.
-: (mixed|nil) If the value is a table, a copy will be returned.
+@ class (string) The finale class name.
+: (table|nil)
 ]]
-function mixin.get_default(class, prop)
-    return default_mixins[class] and default_mixins[class][prop] and copy_table(default_mixins[class][prop]) or nil
+function mixin.get_global_mixin(class)
+    return global_mixins[class] and copy_table(global_mixins[class]) or nil
 end
 
 --[[
-% get_named(class, mixin_name)
+% get_mixin(class, mixin_name)
 
-Retrieves all the methods / properties of a named mixin.
+Library Method: Retrieves a copy of all the methods and properties of mixin.
 
 @ class (string) Finale class.
 @ mixin_name (string) Name of mixin.
 : (table|nil)
 ]]
-function mixin.get_named(class, mixin_name)
+function mixin.get_mixin(class, mixin_name)
     return named_mixins[class] and named_mixins[class][mixin_name] and copy_table(named_mixins[class][mixin_name]) or nil
-end
-
---[[
-% apply_named(object, mixin_name)
-
-Applies a named mixin to an object. See apply_table for more details.
-
-@ object (__FCBase) The object to apply the mixin to.
-@ mixin_name (string) The name of the mixin to apply.
-: (__FCBase) The object that was passed.
-]]
-function mixin.apply_named(object, mixin_name)
-    local class = mixin.get_class_name(object)
-    return mixin.apply_table(object, class and named_mixins[class] and named_mixins[class][mixin_name] or {})
-end
-
---[[
-% apply_table(object, table)
-
-Takes all pairs in the table and copies them over to the target object. If there is an `init` method, it will be called and then removed. This method does not check for conflicts sonit may result in another mixin's method / property being overwritten.
-
-@ object (__FCBase) The target object.
-@ mixin_table (table) Table of properties to apply_table
-: (__FCBase) The object that was passed.
-]]
-function mixin.apply_table(object, mixin_table)
-    for prop, val in pairs(mixin_table) do
-        if type(prop) == 'string' then
-            object[prop] = copy_table(val)
-            object[prop] = copy_table(val)
-        end
-    end
-
-    if mixin_table.init then
-        object:init()
-        object.init = nil
-    end
-
-    return object
 end
 
 -- Keep a copy of the original finale namespace
@@ -238,7 +303,7 @@ local original_finale = finale
 
 -- Turn the finale namespace into a proxy
 finale = setmetatable({}, {
-    __newindex = function(t,k,v) end,
+    __newindex = function(t, k, v) end,
     __index = function(t, k)
         if (type(k) == 'string' and k:sub(-1) == '_') then
             return original_finale[k:sub(1, -2)]
@@ -246,7 +311,7 @@ finale = setmetatable({}, {
 
         local val = original_finale[k]
 
-        if (type(val) == 'table') then
+        if type(val) == 'table' then
             return setmetatable({}, {
                 __index = function(t, k) return original_finale[k] end,
                 __call = function(...)
@@ -260,10 +325,8 @@ finale = setmetatable({}, {
 })
 
 return {
-    register_default = mixin.register_default,
-    register_named = mixin.register_named,
-    get_default = mixin.get_default,
-    get_named = mixin.get_named,
-    apply_named = mixin.apply_named,
-    apply_table = mixin.apply_table,
+    register_global_mixin = mixin.register_global_mixin,
+    register_mixin = mixin.register_mixin,
+    get_global_mixin = mixin.get_global_mixin,
+    get_mixin = mixin.get_mixin,
 }


### PR DESCRIPTION
This is a quick follow up PR with some improvements to Fluid Mixins, mainly based around tighter enforcement of some OOP principles.

- Default mixins have been renamed to global mixins (that's what I had originally written in the comments and I think it is a more appropriate name).
- Applying named mixins is now done on the object itself via `object:apply_mixin('foo')`.
- Objects are now aware of which named mixins have been applied.
- It is now possible to check if an object has a named mixin applied by calling `object:has_mixin('foo')`. It is also possible to check if a global mixin is in place by calling `object:has_mixin('global')`.
- Named mixins can only be registered once and cannot be called 'global'.
- Properties cannot be overridden with methods and vice-versa.
- Errors are now caught and rethrown so that they display at the correct level with the correct line number and the correct method name.
- Aliased table.unpack for Lua 5.1 support.


Error handling proved somewhat tricky to get right but it's turned out better than I initially expected. The last remaining small issue with errors is that for methods called with a semicolon (eg `dialog:ExecuteModal()`), any 'bad argument' errors will have the argument number off by one (because under the hood the actual function call is not made with a semicolon). To fix this properly, there would need to be some way of differentiating whether a function was originally called with a dot or a semicolon but I don't think that's possible. The other option is that I can reduce all bad argument errors by 1, which would fix it for semicolon calls, but break it for dot calls. I guess it would depend on which type of call is more common. It's a very minor issue, but I thought I'd mention it.